### PR TITLE
Handle target disconnection errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": "10.6.0"
   },
   "scripts": {
-    "dev": "./bin/gen-certs && NODE_ENV=development node src/index.js",
+    "dev": "NODE_ENV=development node src/index.js",
     "prod": "NODE_ENV=production node src/index.js",
-    "test": "./bin/gen-certs && NODE_ENV=test mocha --reporter spec 'test/**/*.spec.js'"
+    "test": "NODE_ENV=test mocha --reporter spec 'test/**/*.spec.js'"
   },
   "dependencies": {
     "http": "^0.0.0",

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -105,14 +105,28 @@ describe("secure proxy", () => {
       })
     })
 
-    describe("when target serverdisconnects", () => {
-      beforeEach(() => {
-        wsClient = new WebSocket(`ws://${targetHost}:${proxyPort}?token=${token}`)
-        wsServer.close()
+    describe("when target server disconnects", () => {
+
+      describe("and a websocket is open", () => {
+        beforeEach(() => {
+          wsClient = new WebSocket(`ws://${targetHost}:${proxyPort}?token=${token}`)
+          wsServer.close()
+        })
+
+        it("closes an the websocket with a 503 message", () => {
+          wsClient.on("error", err => expect(err.message).to.eql("Unexpected server response: 503"))
+        })
       })
 
-      it("closes websocket gracefully", () => {
-        wsClient.on("error", err => expect(err.message).to.eql("Unexpected server response: 503"))
+      describe("and a client attempts to open a new websocket", () => {
+        beforeEach(()  =>  {
+          wsServer.close()
+          wsClient = new WebSocket(`ws://${targetHost}:${proxyPort}?token=${token}`)
+        })
+
+        it("responds to a WS upgrade requests with 503 message", () => {
+          wsClient.on("error", err => expect(err.message).to.eql("Unexpected server response: 503"))
+        })
       })
     })
   })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -26,7 +26,7 @@ describe("secure proxy", () => {
 
   after(() => {
     proxy.close()
-    target.close()
+    try { target.close() } catch {}
   })
 
   describe("for an HTTP request", () => {
@@ -46,6 +46,12 @@ describe("secure proxy", () => {
     it("rejects a request with a missing token", async () => {
       const res = await agent.post("/?foo=bar").expect(401)
       expect(res.body).to.eql({ error: "access denied" })
+    })
+
+    it("handles a request to a disconnected server", async () => {
+      await target.close()
+      const response = await agent.post(`/?token=${token}`).send({bar: 'baz'}).expect(503)
+      expect(response.body).to.eql({ error: "service unavailable" })
     })
   })
 

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -92,5 +92,16 @@ describe("secure proxy", () => {
         wsClient.on("error", err => expect(err.message).to.eql("Unexpected server response: 401"))
       })
     })
+
+    describe("when target serverdisconnects", () => {
+      beforeEach(() => {
+        wsClient = new WebSocket(`ws://${targetHost}:${proxyPort}?token=${token}`)
+        wsServer.close()
+      })
+
+      it("closes websocket gracefully", () => {
+        wsClient.on("error", err => expect(err.message).to.eql("Unexpected server response: 503"))
+      })
+    })
   })
 })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -129,5 +129,21 @@ describe("secure proxy", () => {
         })
       })
     })
+
+    describe("when target server disconnects then reconnects", () => {
+      beforeEach(() => {
+        wsServer.close()
+        wsServer = new WebSocket.Server({port: targetWsPort })
+        wsClient = new WebSocket(`ws://${targetHost}:${proxyPort}/?token=${token}`)
+      })
+
+      it("handles websocket upgrade attempts", () => {
+        wsServer.on("connection", ws => ws.on("message", msg => {
+          expect(msg).to.eql("foo")
+          done()
+        }))
+        wsClient.on("open", () => wsClient.send("foo"))
+      })
+    })
   })
 })


### PR DESCRIPTION
after downstream connection to target server has been eliminated:
* keep the proxy running
* if we receive an http request on the proxy, respond with 503 and error message
* if we have a websocket connection, terminate it with a 503 error messages
* if target server reconnects, recover gracefully and handle both http requests and new ws connection attempts